### PR TITLE
Fix(components): prevent gravity canvas from hijacking page scroll (#172)

### DIFF
--- a/src/components/common/Gravity.tsx
+++ b/src/components/common/Gravity.tsx
@@ -284,6 +284,18 @@ const Gravity = forwardRef<GravityRef, GravityProps>(
       });
 
       const mouse = Mouse.create(render.current.canvas);
+
+      // Prevent Matter.js from hijacking the scroll / mousewheel events on the canvas,
+      // which blocks normal page scrolling when hovering over the container.
+      const preventHijack = (e: Event) => {
+        e.stopImmediatePropagation();
+      };
+      if (render.current.canvas) {
+        render.current.canvas.addEventListener("wheel", preventHijack, { capture: true });
+        render.current.canvas.addEventListener("mousewheel", preventHijack, { capture: true });
+        render.current.canvas.addEventListener("DOMMouseScroll", preventHijack, { capture: true });
+      }
+
       mouseConstraint.current = MouseConstraint.create(engine.current, {
         mouse: mouse,
         constraint: {


### PR DESCRIPTION
## Description

Closes #172

This PR fixes the page scrolling getting blocked when the user's cursor is hovering over the technology showcase section.

### The Problem
Matter.js automatically intercepts scroll events (`wheel`, `mousewheel`, and `DOMMouseScroll`) on the canvas and calls `preventDefault()`. This stopped the entire page from scrolling when the cursor hovered over the section.

### The Solution
We added capturing event listeners to the canvas that intercept and stop the scroll events before they reach Matter.js:
- Stops Matter.js from blocking the scroll event.
- Restores normal browser page scrolling.
- Keeps icon-dragging interactions working perfectly.
- Clean and type-safe (no `any` types or hacks used).