### PR TITLE
Add MCP server for Nurui registry discovery and component installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+/src/mcp/node_modules
+/src/mcp/dist

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@
 
 Visit https://nurui.vercel.app/docs/installation to view the documentation.
 
+## MCP Server
+
+Nurui includes a Model Context Protocol server for AI editors and agents that need to search the component registry or fetch install-ready component source.
+
+Package source: [`src/mcp`](src/mcp)
+
+Local development:
+
+```bash
+cd src/mcp
+npm install
+npm test
+```
+
 ## 🚀 Quick Start
 
 ### Option 1: Using Docker (Recommended for Production)

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -63,6 +63,19 @@ Parameters:
 - `name`: required registry item name, for example `gradient-button`
 - `includeSource`: optional boolean, defaults to `false`
 
+### `installRegistryItem`
+
+Installs one registry item into a local project using the same file layout as the Nurui CLI.
+
+Parameters:
+
+- `name`: required registry item name, for example `gradient-button`
+- `projectPath`: absolute path to the target project
+- `language`: optional target language, `ts` or `js`, defaults to `ts`
+- `installDependencies`: optional boolean, defaults to `true`
+- `overwrite`: optional boolean, defaults to `false`
+- `dryRun`: optional boolean, defaults to `false`
+
 ## Development
 
 ```bash

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -1,0 +1,73 @@
+# Nurui MCP
+
+Model Context Protocol server for Nurui components.
+
+The server exposes Nurui's shadcn-compatible registry to MCP clients with a small, token-efficient tool surface. Agents can search or list compact metadata first, then request one component with source code only when needed.
+
+## Usage
+
+```json
+{
+  "mcpServers": {
+    "nurui": {
+      "command": "npx",
+      "args": ["@nurui/mcp"]
+    }
+  }
+}
+```
+
+For local development from this repository:
+
+```json
+{
+  "mcpServers": {
+    "nurui": {
+      "command": "node",
+      "args": ["...../Nurui/src/mcp/dist/index.js"] // absolute path
+    }
+  }
+}
+```
+
+## Tools
+
+### `listRegistryItems`
+
+Lists compact registry item metadata with optional filtering and pagination.
+
+Parameters:
+
+- `kind`: optional kind such as `component` or `registry:component`
+- `query`: optional text filter
+- `limit`: optional result limit, default `25`, max `150`
+- `offset`: optional pagination offset
+
+### `searchRegistryItems`
+
+Ranks matching items by name, title, description, dependency, and source path.
+
+Parameters:
+
+- `query`: required search text
+- `kind`: optional kind filter
+- `limit`: optional result limit, default `25`, max `150`
+- `offset`: optional pagination offset
+
+### `getRegistryItem`
+
+Fetches one registry item with install instructions and file metadata.
+
+Parameters:
+
+- `name`: required registry item name, for example `gradient-button`
+- `includeSource`: optional boolean, defaults to `false`
+
+## Development
+
+```bash
+npm install
+npm test
+```
+
+`npm test` builds the TypeScript source and runs the Node test suite.

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -2,9 +2,22 @@
 
 Model Context Protocol server for Nurui components.
 
-The server exposes Nurui's shadcn-compatible registry to MCP clients with a small, token-efficient tool surface. Agents can search or list compact metadata first, then request one component with source code only when needed.
+This package lets MCP clients such as AI editors, coding agents, and local MCP inspectors search the Nurui registry, fetch component metadata, and install components into a local project without asking the model to copy large source files manually.
+
+## What This Server Does
+
+An MCP server is a small process that exposes tools to an MCP client. In this package, the client starts the Nurui MCP server over stdio (command-line), discovers the tools, and calls them when it needs registry data or wants to install a component.
+
+Main goals:
+
+- Keep browsing responses small.
+- Fetch source only when needed.
+- Let agents install components through a tool instead of copying code from chat.
+- Reuse Nurui's existing registry and CLI-style file layout.
 
 ## Usage
+
+Published package usage:
 
 ```json
 {
@@ -17,35 +30,180 @@ The server exposes Nurui's shadcn-compatible registry to MCP clients with a smal
 }
 ```
 
-For local development from this repository:
+Local repository usage:
 
 ```json
 {
   "mcpServers": {
     "nurui": {
       "command": "node",
-      "args": ["...../Nurui/src/mcp/dist/index.js"] // absolute path
+      "args": [".../Nurui/src/mcp/dist/index.js"],
+      "cwd": ".../Nurui/src/mcp"
     }
   }
 }
 ```
 
+Use absolute paths in the local config. The `.../Nurui` part should be replaced with the full path to your local repository.
+
+MCP Inspector:
+
+```bash
+npx @modelcontextprotocol/inspector node ./dist/index.js
+```
+
+## Development
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Build:
+
+```bash
+npm run build
+```
+
+Run tests:
+
+```bash
+npm test
+```
+
+Run the built server:
+
+```bash
+npm start
+```
+
+## How It Works
+
+Runtime flow:
+
+1. The MCP client starts `dist/index.js`.
+2. `src/index.ts` creates a stdio transport.
+3. `src/server.ts` creates the MCP server instance.
+4. `src/tools.ts` registers the public tools.
+5. Tool handlers call `src/registry-service.ts` or `src/component-installer.ts`.
+6. Responses are wrapped through `src/responses.ts`.
+
+Registry flow:
+
+1. `listRegistryItems` and `searchRegistryItems` load the registry index from `/r/registry.json`.
+2. The registry index is cached for the lifetime of the process.
+3. List and search tools return compact summaries without source code.
+4. `getRegistryItem` fetches `/r/{name}.json` for one component.
+5. `installRegistryItem` fetches the same item with source enabled and writes files directly.
+
+## File Guide
+
+### `src/index.ts`
+
+Package binary entrypoint.
+
+It creates the MCP server, connects it to `StdioServerTransport`, and waits for client requests. This is what runs when the package binary starts.
+
+### `src/server.ts`
+
+Creates the `McpServer` instance and registers all tools.
+
+Keep this file small. Server setup belongs here; registry logic and install logic should stay in service files.
+
+### `src/tools.ts`
+
+Defines the MCP tool surface.
+
+This file contains:
+
+- Tool names
+- Tool descriptions
+- Zod input schemas
+- Tool handlers
+
+When adding a new public MCP tool, register it here with `server.registerTool`.
+
+### `src/registry-service.ts`
+
+Registry read layer.
+
+This file handles:
+
+- registry index loading
+- registry item loading
+- kind normalization
+- filtering
+- search ranking
+- pagination
+- compact and detailed response shapes
+
+This service intentionally keeps source code out of list/search responses.
+
+### `src/component-installer.ts`
+
+Install layer.
+
+This file handles:
+
+- fetching a component with source
+- writing component files
+- writing component CSS files
+- creating `lib/utils.ts` or `lib/utils.js`
+- converting TSX to JSX when `language` is `js`
+- detecting the target project's package manager
+- optionally installing dependencies
+
+The installer follows the same target layout as the Nurui CLI:
+
+- If the target project has `src/`, files go under `src/components/nurui`.
+- If the target project does not have `src/`, files go under `components/nurui`.
+- CSS files go under `components/nurui/styles`.
+- The `cn` helper goes under `lib/utils.ts` or `lib/utils.js`.
+
+### `src/responses.ts`
+
+Small response helpers.
+
+MCP tool calls return a `CallToolResult`. This file keeps success and error response formatting consistent.
+
+### Tests
+
+Tests live beside the source:
+
+- `src/registry-service.test.js`
+- `src/component-installer.test.js`
+
+The tests import from `dist`, so `npm test` builds first and then runs Node's test runner.
+
 ## Tools
 
 ### `listRegistryItems`
 
-Lists compact registry item metadata with optional filtering and pagination.
+Lists registry items as compact summaries.
+
+Use this when the client needs to browse components without loading source code.
 
 Parameters:
 
 - `kind`: optional kind such as `component` or `registry:component`
-- `query`: optional text filter
+- `query`: optional substring filter
 - `limit`: optional result limit, default `25`, max `150`
 - `offset`: optional pagination offset
 
+Returns:
+
+- registry name
+- homepage
+- total result count
+- page metadata
+- compact item summaries
+
 ### `searchRegistryItems`
 
-Ranks matching items by name, title, description, dependency, and source path.
+Searches registry items and ranks matches.
+
+Use this when the user asks for a component by name, use case, dependency, or related keyword.
 
 Parameters:
 
@@ -54,18 +212,33 @@ Parameters:
 - `limit`: optional result limit, default `25`, max `150`
 - `offset`: optional pagination offset
 
+Ranking order:
+
+1. exact name
+2. name prefix
+3. name substring
+4. title
+5. description
+6. fallback search text
+
 ### `getRegistryItem`
 
-Fetches one registry item with install instructions and file metadata.
+Fetches one registry item.
+
+Use this when the client has selected a specific component and needs details.
 
 Parameters:
 
 - `name`: required registry item name, for example `gradient-button`
 - `includeSource`: optional boolean, defaults to `false`
 
+By default this does not include source code. Set `includeSource` to `true` only when the client needs to inspect or explain the code.
+
 ### `installRegistryItem`
 
-Installs one registry item into a local project using the same file layout as the Nurui CLI.
+Installs one registry item into a local project.
+
+Use this when the user wants to add a component to their codebase. This is more efficient than asking the model to read source code and write files manually.
 
 Parameters:
 
@@ -76,11 +249,17 @@ Parameters:
 - `overwrite`: optional boolean, defaults to `false`
 - `dryRun`: optional boolean, defaults to `false`
 
-## Development
+Recommended client flow:
 
-```bash
-npm install
-npm test
-```
+1. Call with `dryRun: true`.
+2. Show the planned files to the user.
+3. Call again with `dryRun: false` after confirmation.
 
-`npm test` builds the TypeScript source and runs the Node test suite.
+## Configuration
+
+Default registry URLs:
+
+- Index: `https://nurui.vercel.app/r/registry.json`
+- Item detail: `https://nurui.vercel.app/r/{name}.json`
+
+The registry URLs are defined as module-level constants in `src/registry-service.ts`, matching the fixed-url style used by the Nurui CLI package. Update those constants if the registry host changes.

--- a/src/mcp/package-lock.json
+++ b/src/mcp/package-lock.json
@@ -1,0 +1,1193 @@
+{
+  "name": "@nurui/mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@nurui/mcp",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^3.25.76"
+      },
+      "bin": {
+        "nurui-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/src/mcp/package-lock.json
+++ b/src/mcp/package-lock.json
@@ -10,13 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "typescript": "^5.9.3",
         "zod": "^3.25.76"
       },
       "bin": {
         "nurui-mcp": "dist/index.js"
-      },
-      "devDependencies": {
-        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=18"
@@ -1122,7 +1120,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/mcp/package.json
+++ b/src/mcp/package.json
@@ -32,10 +32,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "typescript": "^5.9.3",
     "zod": "^3.25.76"
-  },
-  "devDependencies": {
-    "typescript": "^5.9.3"
   },
   "engines": {
     "node": ">=18"

--- a/src/mcp/package.json
+++ b/src/mcp/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@nurui/mcp",
+  "version": "0.1.0",
+  "description": "Model Context Protocol server for Nurui registry components.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/server.js",
+  "types": "./dist/server.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.js"
+    },
+    "./registry-service": {
+      "types": "./dist/registry-service.d.ts",
+      "import": "./dist/registry-service.js"
+    }
+  },
+  "bin": {
+    "nurui-mcp": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build",
+    "start": "node ./dist/index.js",
+    "test": "npm run build && node --test"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/src/mcp/src/component-installer.test.js
+++ b/src/mcp/src/component-installer.test.js
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createComponentInstaller } from "../dist/component-installer.js";
+
+const registryItem = {
+  name: "gradient-button",
+  dependencies: ["clsx", "tailwind-merge"],
+  files: [
+    {
+      path: "./src/components/nurui/gradient-button.tsx",
+      type: "registry:component",
+      content: "import { cn } from '@/lib/utils';\nexport default function Button() { return <button />; }\n",
+    },
+    {
+      path: "./src/components/nurui/styles/gradient-button.css",
+      type: "registry:component",
+      content: ".gradient-button { color: red; }",
+    },
+  ],
+};
+
+function createRegistryService() {
+  return {
+    async getRegistryItem(name, options) {
+      assert.equal(name, "gradient-button");
+      assert.equal(options.includeSource, true);
+      return registryItem;
+    },
+  };
+}
+
+test("installs component files and utils into a src project", async () => {
+  const projectPath = await mkdtemp(path.join(tmpdir(), "nurui-mcp-install-"));
+  await mkdir(path.join(projectPath, "src"));
+
+  try {
+    const installer = createComponentInstaller({
+      registryService: createRegistryService(),
+    });
+
+    const result = await installer.installComponent({
+      name: "gradient-button",
+      projectPath,
+      language: "ts",
+      installDependencies: false,
+    });
+
+    assert.deepEqual(result.writtenFiles.sort(), [
+      path.join(projectPath, "src", "components", "nurui", "gradient-button.tsx"),
+      path.join(projectPath, "src", "components", "nurui", "styles", "gradient-button.css"),
+      path.join(projectPath, "src", "lib", "utils.ts"),
+    ].sort());
+
+    const component = await readFile(
+      path.join(projectPath, "src", "components", "nurui", "gradient-button.tsx"),
+      "utf8",
+    );
+    assert.match(component, /export default function Button/);
+    assert.equal(result.dependencies.installed, false);
+    assert.deepEqual(result.dependencies.packages, ["clsx", "tailwind-merge"]);
+  } finally {
+    await rm(projectPath, { recursive: true, force: true });
+  }
+});
+
+test("dry run reports planned writes without changing files", async () => {
+  const projectPath = await mkdtemp(path.join(tmpdir(), "nurui-mcp-dry-run-"));
+
+  try {
+    const installer = createComponentInstaller({
+      registryService: createRegistryService(),
+    });
+
+    const result = await installer.installComponent({
+      name: "gradient-button",
+      projectPath,
+      dryRun: true,
+    });
+
+    assert.equal(result.dryRun, true);
+    assert.equal(result.writtenFiles.length, 0);
+    assert.equal(result.plannedFiles.length, 3);
+  } finally {
+    await rm(projectPath, { recursive: true, force: true });
+  }
+});

--- a/src/mcp/src/component-installer.ts
+++ b/src/mcp/src/component-installer.ts
@@ -1,0 +1,318 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import ts from "typescript";
+
+import { registryService } from "./registry-service.js";
+
+type Language = "ts" | "js";
+type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
+
+interface RegistryFileWithContent {
+  path: string;
+  type?: string;
+  content?: string;
+}
+
+interface RegistryItemWithContent {
+  name: string;
+  dependencies?: string[];
+  files: RegistryFileWithContent[];
+}
+
+interface RegistryServiceLike {
+  getRegistryItem(
+    name: string,
+    options: { includeSource: true },
+  ): Promise<RegistryItemWithContent>;
+}
+
+interface SpawnResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+interface ComponentInstallerOptions {
+  registryService?: RegistryServiceLike;
+  spawnCommand?: (
+    command: string,
+    args: string[],
+    options: { cwd: string },
+  ) => Promise<SpawnResult>;
+}
+
+/**
+ * Input accepted by the install tool.
+ *
+ * `projectPath` is always resolved before writes. `dryRun` computes the same
+ * paths without touching the filesystem or installing packages.
+ */
+export interface InstallComponentArgs {
+  name: string;
+  projectPath: string;
+  language?: Language;
+  installDependencies?: boolean;
+  overwrite?: boolean;
+  dryRun?: boolean;
+}
+
+/**
+ * Result returned by the install tool.
+ *
+ * `plannedFiles` includes every target path. `writtenFiles` and `skippedFiles`
+ * describe what actually happened during a non-dry run.
+ */
+export interface InstallComponentResult {
+  component: string;
+  projectPath: string;
+  language: Language;
+  dryRun: boolean;
+  writtenFiles: string[];
+  skippedFiles: string[];
+  plannedFiles: string[];
+  dependencies: {
+    installed: boolean;
+    packages: string[];
+    command?: string;
+    exitCode?: number | null;
+    stdout?: string;
+    stderr?: string;
+  };
+}
+
+// Local `cn` helper written when the target project does not have one yet.
+const UTILS_CONTENT: Record<Language, string> = {
+  ts: `import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+`,
+  js: `import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs) {
+  return twMerge(clsx(inputs));
+}
+`,
+};
+
+// Detect the package manager from lockfiles in the target project.
+function detectPackageManager(projectPath: string): PackageManager {
+  if (existsSync(path.join(projectPath, "yarn.lock"))) return "yarn";
+  if (existsSync(path.join(projectPath, "pnpm-lock.yaml"))) return "pnpm";
+  if (existsSync(path.join(projectPath, "bun.lockb"))) return "bun";
+  return "npm";
+}
+
+// Map package-manager names to their dependency install command.
+function getInstallCommand(
+  packageManager: PackageManager,
+  packages: string[],
+): { command: string; args: string[] } {
+  if (packageManager === "npm") {
+    return { command: "npm", args: ["install", ...packages] };
+  }
+
+  return { command: packageManager, args: ["add", ...packages] };
+}
+
+// Default dependency installer used by real MCP calls.
+function defaultSpawnCommand(
+  command: string,
+  args: string[],
+  options: { cwd: string },
+): Promise<SpawnResult> {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      shell: process.platform === "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+// Match the CLI layout: use `src/` when it exists, otherwise write at project root.
+function getProjectDirs(projectPath: string) {
+  const hasSrc = existsSync(path.join(projectPath, "src"));
+  const sourceRoot = hasSrc ? path.join(projectPath, "src") : projectPath;
+
+  return {
+    componentDir: path.join(sourceRoot, "components", "nurui"),
+    stylesDir: path.join(sourceRoot, "components", "nurui", "styles"),
+    libDir: path.join(sourceRoot, "lib"),
+  };
+}
+
+// Convert TSX component files when the caller requests JavaScript output.
+function convertTsxToJsx(code: string): string {
+  return ts.transpileModule(code, {
+    compilerOptions: {
+      jsx: ts.JsxEmit.Preserve,
+      target: ts.ScriptTarget.ESNext,
+      module: ts.ModuleKind.ESNext,
+      allowJs: true,
+    },
+    fileName: "component.tsx",
+  }).outputText;
+}
+
+// Resolve a registry file path into its local project destination.
+function getTargetPath(
+  filePath: string,
+  dirs: ReturnType<typeof getProjectDirs>,
+  language: Language,
+): string {
+  const fileName = path.basename(filePath);
+
+  if (fileName.endsWith(".css")) {
+    return path.join(dirs.stylesDir, fileName);
+  }
+
+  const targetName =
+    language === "js" ? fileName.replace(/\.tsx$/, ".jsx") : fileName;
+
+  return path.join(dirs.componentDir, targetName);
+}
+
+// Write a file unless it already exists and overwrite is disabled.
+async function writeProjectFile(
+  targetPath: string,
+  content: string,
+  overwrite: boolean,
+): Promise<"written" | "skipped"> {
+  if (!overwrite && existsSync(targetPath)) {
+    return "skipped";
+  }
+
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, content, "utf8");
+
+  return "written";
+}
+
+/**
+ * Create a component installer backed by a registry service.
+ *
+ * The default instance fetches registry items from the live registry service
+ * and installs dependencies with the package manager detected in `projectPath`.
+ */
+export function createComponentInstaller(options: ComponentInstallerOptions = {}) {
+  const source = options.registryService ?? registryService;
+  const spawnCommand = options.spawnCommand ?? defaultSpawnCommand;
+
+  return {
+    /**
+     * Install a registry item into a local project.
+     *
+     * This fetches source internally, writes component/style files, creates the
+     * `cn` utility helper, and optionally installs dependencies.
+     */
+    async installComponent(args: InstallComponentArgs): Promise<InstallComponentResult> {
+      const componentName = args.name.trim();
+      if (!componentName) throw new Error("Component name is required.");
+
+      const projectPath = path.resolve(args.projectPath);
+      const language = args.language ?? "ts";
+      const installDependencies = args.installDependencies ?? true;
+      const overwrite = args.overwrite ?? false;
+      const dryRun = args.dryRun ?? false;
+      const dirs = getProjectDirs(projectPath);
+
+      // Installation needs file contents even though browse/detail calls avoid them.
+      const item = await source.getRegistryItem(componentName, {
+        includeSource: true,
+      });
+
+      // Ignore registry file entries without content; there is nothing to write.
+      const files = item.files.filter((file) => typeof file.content === "string");
+      const utilsPath = path.join(dirs.libDir, `utils.${language}`);
+      const plannedFiles = [
+        ...files.map((file) => getTargetPath(file.path, dirs, language)),
+        utilsPath,
+      ];
+      const writtenFiles: string[] = [];
+      const skippedFiles: string[] = [];
+
+      if (!dryRun) {
+        // Write component and style files first.
+        for (const file of files) {
+          const targetPath = getTargetPath(file.path, dirs, language);
+          const content =
+            language === "js" && file.path.endsWith(".tsx")
+              ? convertTsxToJsx(file.content as string)
+              : (file.content as string);
+          const status = await writeProjectFile(targetPath, content, overwrite);
+
+          if (status === "written") writtenFiles.push(targetPath);
+          else skippedFiles.push(targetPath);
+        }
+
+        // Always ensure the utility helper exists, matching the CLI behavior.
+        const status = await writeProjectFile(
+          utilsPath,
+          UTILS_CONTENT[language],
+          overwrite,
+        );
+
+        if (status === "written") writtenFiles.push(utilsPath);
+        else skippedFiles.push(utilsPath);
+      }
+
+      // The utility helper depends on these packages even if the component does not list them.
+      const packages = [
+        ...new Set(
+          [...(item.dependencies ?? []), "clsx", "tailwind-merge"].filter(Boolean),
+        ),
+      ];
+      const dependencies: InstallComponentResult["dependencies"] = {
+        installed: false,
+        packages,
+      };
+
+      if (!dryRun && installDependencies && packages.length > 0) {
+        // Dependency install is intentionally last so file writes are visible even if it fails.
+        const packageManager = detectPackageManager(projectPath);
+        const installCommand = getInstallCommand(packageManager, packages);
+        const result = await spawnCommand(installCommand.command, installCommand.args, {
+          cwd: projectPath,
+        });
+
+        dependencies.installed = result.code === 0;
+        dependencies.command = [installCommand.command, ...installCommand.args].join(" ");
+        dependencies.exitCode = result.code;
+        dependencies.stdout = result.stdout.slice(-4000);
+        dependencies.stderr = result.stderr.slice(-4000);
+      }
+
+      return {
+        component: componentName,
+        projectPath,
+        language,
+        dryRun,
+        writtenFiles,
+        skippedFiles,
+        plannedFiles,
+        dependencies,
+      };
+    },
+  };
+}
+
+export const componentInstaller = createComponentInstaller();

--- a/src/mcp/src/index.ts
+++ b/src/mcp/src/index.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+import { createServer } from "./server.js";
+
+const server = createServer();
+const transport = new StdioServerTransport();
+
+await server.connect(transport);

--- a/src/mcp/src/registry-service.test.js
+++ b/src/mcp/src/registry-service.test.js
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createRegistryService,
+  normalizeKind,
+  toRegistryItemSummary,
+} from "../dist/registry-service.js";
+
+const registry = {
+  name: "nurui",
+  homepage: "https://nurui.vercel.app",
+  items: [
+    {
+      name: "gradient-button",
+      type: "registry:component",
+      title: "Gradient Button",
+      description: "Animated conic gradient button.",
+      dependencies: ["clsx", "tailwind-merge"],
+      devDependencies: [],
+      registryDependencies: [],
+      files: [
+        {
+          path: "./src/components/nurui/gradient-button.tsx",
+          type: "registry:component",
+        },
+      ],
+    },
+    {
+      name: "spotlight-card",
+      type: "registry:block",
+      title: "Spotlight Card",
+      description: "Interactive card with cursor spotlight.",
+      dependencies: ["motion"],
+      devDependencies: [],
+      registryDependencies: [],
+      files: [],
+    },
+  ],
+};
+
+const item = {
+  ...registry.items[0],
+  files: [
+    {
+      path: "./src/components/nurui/gradient-button.tsx",
+      type: "registry:component",
+      content: "export function GradientButton() { return <button /> }",
+    },
+  ],
+};
+
+function createFetch() {
+  return async (url) => {
+    if (url.endsWith("/r/registry.json")) {
+      return Response.json(registry);
+    }
+
+    if (url.endsWith("/r/gradient-button.json")) {
+      return Response.json(item);
+    }
+
+    return new Response("Not found", { status: 404 });
+  };
+}
+
+test("normalizeKind accepts friendly and registry-prefixed kinds", () => {
+  assert.equal(normalizeKind("component"), "registry:component");
+  assert.equal(normalizeKind("registry:block"), "registry:block");
+});
+
+test("toRegistryItemSummary omits source content", () => {
+  assert.deepEqual(toRegistryItemSummary(item), {
+    name: "gradient-button",
+    type: "registry:component",
+    title: "Gradient Button",
+    description: "Animated conic gradient button.",
+    dependencies: ["clsx", "tailwind-merge"],
+    devDependencies: [],
+    registryDependencies: [],
+    files: ["./src/components/nurui/gradient-button.tsx"],
+  });
+});
+
+test("listRegistryItems paginates compact summaries", async () => {
+  const service = createRegistryService({
+    baseUrl: "https://nurui.vercel.app",
+    fetch: createFetch(),
+  });
+
+  const result = await service.listRegistryItems({ limit: 1, offset: 1 });
+
+  assert.equal(result.registry, "nurui");
+  assert.equal(result.total, 2);
+  assert.equal(result.count, 1);
+  assert.equal(result.hasMore, false);
+  assert.equal(result.items[0].name, "spotlight-card");
+  assert.equal(result.items[0].files.length, 0);
+});
+
+test("searchRegistryItems ranks exact name matches before text matches", async () => {
+  const service = createRegistryService({
+    baseUrl: "https://nurui.vercel.app",
+    fetch: createFetch(),
+  });
+
+  const result = await service.searchRegistryItems({ query: "gradient" });
+
+  assert.equal(result.total, 1);
+  assert.equal(result.items[0].name, "gradient-button");
+});
+
+test("getRegistryItem returns install instructions without source by default", async () => {
+  const service = createRegistryService({
+    baseUrl: "https://nurui.vercel.app",
+    fetch: createFetch(),
+  });
+
+  const result = await service.getRegistryItem("gradient-button");
+
+  assert.equal(result.name, "gradient-button");
+  assert.equal(result.install.command, "npx nurui add gradient-button");
+  assert.equal(result.files[0].content, undefined);
+});
+
+test("getRegistryItem can include source content on demand", async () => {
+  const service = createRegistryService({
+    baseUrl: "https://nurui.vercel.app",
+    fetch: createFetch(),
+  });
+
+  const result = await service.getRegistryItem("gradient-button", {
+    includeSource: true,
+  });
+
+  assert.match(result.files[0].content, /GradientButton/);
+});

--- a/src/mcp/src/registry-service.ts
+++ b/src/mcp/src/registry-service.ts
@@ -1,0 +1,357 @@
+const DEFAULT_BASE_URL = "https://nurui.vercel.app";
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 150;
+
+export interface RegistryFile {
+  path: string;
+  type?: string;
+  content?: string;
+}
+
+export interface RegistryItem {
+  name: string;
+  type: string;
+  title?: string;
+  description?: string;
+  dependencies?: string[];
+  devDependencies?: string[];
+  registryDependencies?: string[];
+  files?: RegistryFile[];
+}
+
+export interface Registry {
+  name?: string;
+  homepage?: string;
+  items?: RegistryItem[];
+}
+
+export interface RegistryServiceOptions {
+  baseUrl?: string;
+  indexUrl?: string;
+  fetch?: typeof fetch;
+}
+
+export interface ListRegistryItemsArgs {
+  kind?: string;
+  query?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface SearchRegistryItemsArgs extends ListRegistryItemsArgs {
+  query: string;
+}
+
+export interface GetRegistryItemOptions {
+  includeSource?: boolean;
+}
+
+export interface RegistryItemSummary {
+  name: string;
+  type: string;
+  title: string;
+  description?: string;
+  dependencies: string[];
+  devDependencies: string[];
+  registryDependencies: string[];
+  files: string[];
+}
+
+export interface RegistryItemDetail extends Omit<RegistryItemSummary, "files"> {
+  files: RegistryFile[];
+}
+
+// Normalize configured URLs before composing registry paths.
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+// Enforce server-side page bounds.
+function clampLimit(limit: number | undefined): number {
+  if (!Number.isFinite(limit)) return DEFAULT_LIMIT;
+  return Math.min(Math.max(Math.trunc(limit as number), 1), MAX_LIMIT);
+}
+
+// Invalid offsets fall back to the first page.
+function clampOffset(offset: number | undefined): number {
+  if (!Number.isFinite(offset)) return 0;
+  return Math.max(Math.trunc(offset as number), 0);
+}
+
+// Derive a readable title when the registry item does not provide one.
+function titleFromName(name: string): string {
+  return name
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+// Normalize optional arrays from registry data.
+function cleanArray<T>(value: T[] | undefined): T[] {
+  return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+// Convert registry files into the response shape used by detail lookups.
+function getFiles(files: RegistryFile[] | undefined, includeSource = false) {
+  return cleanArray(files).map((file) => {
+    const result: RegistryFile = {
+      path: file.path,
+      type: file.type,
+    };
+
+    // Source content is opt-in to keep default responses small.
+    if (includeSource && typeof file.content === "string") {
+      result.content = file.content;
+    }
+
+    return result;
+  });
+}
+
+// Central search index used by both filtering and ranking.
+function getSearchText(item: RegistryItem): string {
+  return [
+    item.name,
+    item.title,
+    item.description,
+    item.type,
+    ...cleanArray(item.dependencies),
+    ...cleanArray(item.registryDependencies),
+    ...cleanArray(item.files).map((file) => file.path),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+// Return a fixed relevance score for the current query.
+function scoreItem(item: RegistryItem, query: string): number {
+  const name = item.name.toLowerCase();
+  const title = (item.title ?? "").toLowerCase();
+  const description = (item.description ?? "").toLowerCase();
+  const haystack = getSearchText(item);
+
+  // Ranking order:
+  // exact name > name prefix > name substring > title > description > fallback text hit
+  if (name === query) return 100;
+  if (name.startsWith(query)) return 80;
+  if (name.includes(query)) return 60;
+  if (title.includes(query)) return 40;
+  if (description.includes(query)) return 30;
+  if (haystack.includes(query)) return 10;
+  return 0;
+}
+
+// Shared fetch wrapper for registry endpoints.
+async function fetchJson<T>(fetchImpl: typeof fetch, url: string): Promise<T> {
+  const response = await fetchImpl(url);
+
+  if (!response.ok) {
+    throw new Error(`Request failed with ${response.status} for ${url}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+/**
+ * Normalize the incoming kind filter.
+ *
+ * The service accepts either the short form or the fully-qualified registry
+ * form and compares everything in canonical form downstream.
+ */
+export function normalizeKind(kind?: string): string | undefined {
+  if (!kind) return undefined;
+  return kind.startsWith("registry:") ? kind : `registry:${kind}`;
+}
+
+/**
+ * Build the compact item shape used by list and search responses.
+ *
+ * This drops file contents and keeps only the metadata needed for browsing.
+ */
+export function toRegistryItemSummary(item: RegistryItem): RegistryItemSummary {
+  return {
+    name: item.name,
+    type: item.type,
+    title: item.title ?? titleFromName(item.name),
+    description: item.description,
+    dependencies: cleanArray(item.dependencies),
+    devDependencies: cleanArray(item.devDependencies),
+    registryDependencies: cleanArray(item.registryDependencies),
+    files: cleanArray(item.files).map((file) => file.path),
+  };
+}
+
+/**
+ * Build the detailed item shape used by `getRegistryItem`.
+ *
+ * The field set matches the summary response, with file entries expanded into
+ * objects and source content added only when requested.
+ */
+export function toRegistryItemDetail(
+  item: RegistryItem,
+  { includeSource = false }: GetRegistryItemOptions = {},
+): RegistryItemDetail {
+  const summary = toRegistryItemSummary(item);
+
+  return {
+    ...summary,
+    files: getFiles(item.files, includeSource),
+  };
+}
+
+/**
+ * Create a registry service bound to a base URL, index URL, and fetch
+ * implementation.
+ *
+ * The service reads the registry index lazily, caches it for the lifetime of
+ * the process, and fetches item detail JSON on demand.
+ */
+export function createRegistryService(options: RegistryServiceOptions = {}) {
+  // `baseUrl` drives docs and per-item JSON URLs.
+  // `indexUrl` stays overridable for tests and alternate feeds.
+  const baseUrl = trimTrailingSlash(
+    options.baseUrl ??
+      process.env.NURUI_REGISTRY_BASE_URL ??
+      process.env.NURUI_BASE_URL ??
+      DEFAULT_BASE_URL,
+  );
+  const indexUrl =
+    options.indexUrl ??
+    process.env.NURUI_REGISTRY_INDEX_URL ??
+    `${baseUrl}/r/registry.json`;
+  const fetchImpl = options.fetch ?? fetch;
+
+  let registryPromise: Promise<Registry> | undefined;
+
+  /**
+   * Load the registry index once and reuse it across calls.
+   *
+   * List and search operations all depend on the same index payload, so the
+   * service memoizes the request instead of refetching it per tool call.
+   */
+  async function getRegistry(): Promise<Registry> {
+    // Cache the index for the process lifetime.
+    registryPromise ??= fetchJson<Registry>(fetchImpl, indexUrl);
+    return registryPromise;
+  }
+
+  /**
+   * Apply page bounds to an already-filtered item set.
+   *
+   * Pagination happens after filtering or ranking so `total`, `count`, and
+   * `hasMore` describe the final result set.
+   */
+  function paginate(
+    items: RegistryItem[],
+    limit: number | undefined,
+    offset: number | undefined,
+  ) {
+    // Pagination is applied after filtering/ranking.
+    const safeLimit = clampLimit(limit);
+    const safeOffset = clampOffset(offset);
+    const page = items.slice(safeOffset, safeOffset + safeLimit);
+
+    return {
+      total: items.length,
+      count: page.length,
+      limit: safeLimit,
+      offset: safeOffset,
+      hasMore: safeOffset + page.length < items.length,
+      items: page.map(toRegistryItemSummary),
+    };
+  }
+
+  /**
+   * Filter items by normalized kind and substring query.
+   *
+   * Kind matching is exact once normalized. Query matching uses the shared
+   * search index built by `getSearchText`.
+   */
+  function filterItems(items: RegistryItem[], args: ListRegistryItemsArgs = {}) {
+    const normalizedKind = normalizeKind(args.kind);
+    const normalizedQuery = args.query?.trim().toLowerCase();
+
+    // Kind match is exact after normalization. Query match is substring-based.
+    return items.filter((item) => {
+      if (normalizedKind && item.type !== normalizedKind) return false;
+      if (!normalizedQuery) return true;
+      return getSearchText(item).includes(normalizedQuery);
+    });
+  }
+
+  return {
+    /**
+     * List registry items with optional kind and query filters.
+     *
+     * This is the lowest-cost read path. It always returns compact summaries.
+     */
+    async listRegistryItems(args: ListRegistryItemsArgs = {}) {
+      const registry = await getRegistry();
+      const filtered = filterItems(registry.items ?? [], args);
+      const page = paginate(filtered, args.limit, args.offset);
+
+      return {
+        registry: registry.name,
+        homepage: registry.homepage,
+        ...page,
+      };
+    },
+
+    /**
+     * Search registry items and return ranked summary results.
+     *
+     * Ranking is deterministic for equal scores because the final sort key is
+     * the item name.
+     */
+    async searchRegistryItems(args: SearchRegistryItemsArgs) {
+      const query = args.query?.trim().toLowerCase();
+      if (!query) throw new Error("Search query is required.");
+
+      const registry = await getRegistry();
+      const kindFiltered = filterItems(registry.items ?? [], { kind: args.kind });
+
+      // Drop non-matches, then sort by score and stable name order.
+      const ranked = kindFiltered
+        .map((item) => ({ item, score: scoreItem(item, query) }))
+        .filter((entry) => entry.score > 0)
+        .sort((a, b) => b.score - a.score || a.item.name.localeCompare(b.item.name))
+        .map((entry) => entry.item);
+      const page = paginate(ranked, args.limit, args.offset);
+
+      return {
+        registry: registry.name,
+        query: args.query,
+        ...page,
+      };
+    },
+
+    /**
+     * Fetch one registry item and attach install-oriented metadata.
+     *
+     * The raw item payload comes from the per-item JSON file. The service adds
+     * docs and install URLs so MCP callers do not have to reconstruct them.
+     */
+    async getRegistryItem(name: string, options: GetRegistryItemOptions = {}) {
+      if (!name?.trim()) throw new Error("Registry item name is required.");
+
+      const itemName = name.trim();
+      const url = `${baseUrl}/r/${encodeURIComponent(itemName)}.json`;
+      const item = await fetchJson<RegistryItem>(fetchImpl, url);
+
+      // Attach docs and install metadata expected by MCP callers.
+      return {
+        ...toRegistryItemDetail(item, options),
+        docsUrl: `${baseUrl}/docs/${itemName}`,
+        registryUrl: url,
+        install: {
+          command: `npx nurui add ${itemName}`,
+          shadcnCompatibleUrl: `${baseUrl}/r/${itemName}.json`,
+        },
+      };
+    },
+  };
+}
+
+export const registryService = createRegistryService();

--- a/src/mcp/src/registry-service.ts
+++ b/src/mcp/src/registry-service.ts
@@ -1,4 +1,5 @@
-const DEFAULT_BASE_URL = "https://nurui.vercel.app";
+const REGISTRY_BASE_URL = "https://nurui.vercel.app";
+const REGISTRY_INDEX_URL = `${REGISTRY_BASE_URL}/r/registry.json`;
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 150;
 
@@ -210,17 +211,9 @@ export function toRegistryItemDetail(
  */
 export function createRegistryService(options: RegistryServiceOptions = {}) {
   // `baseUrl` drives docs and per-item JSON URLs.
-  // `indexUrl` stays overridable for tests and alternate feeds.
-  const baseUrl = trimTrailingSlash(
-    options.baseUrl ??
-      process.env.NURUI_REGISTRY_BASE_URL ??
-      process.env.NURUI_BASE_URL ??
-      DEFAULT_BASE_URL,
-  );
-  const indexUrl =
-    options.indexUrl ??
-    process.env.NURUI_REGISTRY_INDEX_URL ??
-    `${baseUrl}/r/registry.json`;
+  // `indexUrl` stays overridable for tests.
+  const baseUrl = trimTrailingSlash(options.baseUrl ?? REGISTRY_BASE_URL);
+  const indexUrl = options.indexUrl ?? REGISTRY_INDEX_URL;
   const fetchImpl = options.fetch ?? fetch;
 
   let registryPromise: Promise<Registry> | undefined;

--- a/src/mcp/src/responses.ts
+++ b/src/mcp/src/responses.ts
@@ -1,0 +1,35 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+/** Wraps JSON data in the text response shape expected by MCP tool calls. */
+export function createTextResponse(value: unknown): CallToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(value, null, 2),
+      },
+    ],
+  };
+}
+
+/** Returns a structured MCP error without throwing through the transport layer. */
+export function createErrorResponse(message: string, error: unknown): CallToolResult {
+  const detail = error instanceof Error ? error.message : String(error);
+
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            error: message,
+            detail,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}

--- a/src/mcp/src/server.ts
+++ b/src/mcp/src/server.ts
@@ -1,0 +1,15 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import pkg from "../package.json" with { type: "json" };
+import { registerTools } from "./tools.js";
+
+export function createServer(): McpServer {
+  const server = new McpServer({
+    name: "@nurui/mcp",
+    version: pkg.version,
+  });
+
+  registerTools(server);
+
+  return server;
+}

--- a/src/mcp/src/tools.ts
+++ b/src/mcp/src/tools.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
+import { componentInstaller } from "./component-installer.js";
 import { registryService } from "./registry-service.js";
 import { createErrorResponse, createTextResponse } from "./responses.js";
 
@@ -67,7 +68,42 @@ const getRegistryItemSchema = {
   includeSource: z
     .boolean()
     .optional()
-    .describe("Include file contents. Leave this off unless you really need the code."),
+    .describe(
+      "Include file contents. Leave this off unless you really need the code.",
+    ),
+};
+
+const installRegistryItemSchema = {
+  name: z
+    .string()
+    .min(1)
+    .describe("Exact Nurui registry item name, for example gradient-button."),
+  projectPath: z
+    .string()
+    .min(1)
+    .describe(
+      "Absolute path to the project where the component should be installed.",
+    ),
+  language: z
+    .enum(["ts", "js"])
+    .optional()
+    .describe("Target language for component files. Defaults to ts."),
+  installDependencies: z
+    .boolean()
+    .optional()
+    .describe(
+      "Install npm dependencies after writing files. Defaults to false.",
+    ),
+  overwrite: z
+    .boolean()
+    .optional()
+    .describe("Overwrite existing component files. Defaults to false."),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      "Return planned changes without writing files. Defaults to false.",
+    ),
 };
 
 export function registerTools(server: McpServer): void {
@@ -80,9 +116,14 @@ export function registerTools(server: McpServer): void {
     },
     async (args) => {
       try {
-        return createTextResponse(await registryService.listRegistryItems(args));
+        return createTextResponse(
+          await registryService.listRegistryItems(args),
+        );
       } catch (error) {
-        return createErrorResponse("Failed to list Nurui registry items.", error);
+        return createErrorResponse(
+          "Failed to list Nurui registry items.",
+          error,
+        );
       }
     },
   );
@@ -96,9 +137,14 @@ export function registerTools(server: McpServer): void {
     },
     async (args) => {
       try {
-        return createTextResponse(await registryService.searchRegistryItems(args));
+        return createTextResponse(
+          await registryService.searchRegistryItems(args),
+        );
       } catch (error) {
-        return createErrorResponse("Failed to search Nurui registry items.", error);
+        return createErrorResponse(
+          "Failed to search Nurui registry items.",
+          error,
+        );
       }
     },
   );
@@ -120,6 +166,27 @@ export function registerTools(server: McpServer): void {
       } catch (error) {
         return createErrorResponse(
           `Failed to fetch Nurui registry item "${args.name}".`,
+          error,
+        );
+      }
+    },
+  );
+
+  server.registerTool(
+    "installRegistryItem",
+    {
+      description:
+        "Install a Nurui registry item into a local project using the same file layout as the CLI.",
+      inputSchema: installRegistryItemSchema,
+    },
+    async (args) => {
+      try {
+        return createTextResponse(
+          await componentInstaller.installComponent(args),
+        );
+      } catch (error) {
+        return createErrorResponse(
+          `Failed to install Nurui registry item "${args.name}".`,
           error,
         );
       }

--- a/src/mcp/src/tools.ts
+++ b/src/mcp/src/tools.ts
@@ -1,0 +1,128 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { registryService } from "./registry-service.js";
+import { createErrorResponse, createTextResponse } from "./responses.js";
+
+// Fewer tools makes it easier for the model to pick the right one.
+const listRegistryItemsSchema = {
+  kind: z
+    .string()
+    .optional()
+    .describe(
+      "Optional kind filter. Accepts friendly values like component or full values like registry:component.",
+    ),
+  query: z
+    .string()
+    .optional()
+    .describe(
+      "Optional text filter over item names, titles, descriptions, dependencies, and file paths.",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(150)
+    .optional()
+    .describe("Maximum number of items to return. Defaults to 25."),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Pagination offset. Defaults to 0."),
+};
+
+const searchRegistryItemsSchema = {
+  query: z
+    .string()
+    .min(1)
+    .describe(
+      "Search query matched against Nurui component names, descriptions, dependencies, and file paths.",
+    ),
+  kind: z
+    .string()
+    .optional()
+    .describe("Optional kind filter such as component or registry:component."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(150)
+    .optional()
+    .describe("Maximum number of ranked results to return. Defaults to 25."),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Pagination offset for ranked results. Defaults to 0."),
+};
+
+const getRegistryItemSchema = {
+  name: z
+    .string()
+    .min(1)
+    .describe("Exact Nurui registry item name, for example gradient-button."),
+  includeSource: z
+    .boolean()
+    .optional()
+    .describe("Include file contents. Leave this off unless you really need the code."),
+};
+
+export function registerTools(server: McpServer): void {
+  server.registerTool(
+    "listRegistryItems",
+    {
+      description:
+        "List Nurui registry items with compact metadata, filters, and pagination.",
+      inputSchema: listRegistryItemsSchema,
+    },
+    async (args) => {
+      try {
+        return createTextResponse(await registryService.listRegistryItems(args));
+      } catch (error) {
+        return createErrorResponse("Failed to list Nurui registry items.", error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "searchRegistryItems",
+    {
+      description:
+        "Search Nurui registry items by name, dependency, source path, or use-case keywords.",
+      inputSchema: searchRegistryItemsSchema,
+    },
+    async (args) => {
+      try {
+        return createTextResponse(await registryService.searchRegistryItems(args));
+      } catch (error) {
+        return createErrorResponse("Failed to search Nurui registry items.", error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "getRegistryItem",
+    {
+      description:
+        "Get install instructions and detailed metadata for one Nurui registry item, optionally including source.",
+      inputSchema: getRegistryItemSchema,
+    },
+    async (args) => {
+      try {
+        return createTextResponse(
+          await registryService.getRegistryItem(args.name, {
+            includeSource: args.includeSource,
+          }),
+        );
+      } catch (error) {
+        return createErrorResponse(
+          `Failed to fetch Nurui registry item "${args.name}".`,
+          error,
+        );
+      }
+    },
+  );
+}

--- a/src/mcp/tsconfig.json
+++ b/src/mcp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
This PR adds a standalone MCP server package for Nurui under `src/mcp`. The server exposes Nurui’s component registry to MCP-compatible clients so agents can search, inspect, and install components without manually copying large source-code responses.

## Tools Added

- `listRegistryItems`: Browse compact registry metadata with filtering and pagination.
- `searchRegistryItems`: Search registry items by name, description, dependency, and file path.
- `getRegistryItem`: Fetch one registry item with install metadata and optional source.
- `installRegistryItem`: Install a registry item into a local project using the same layout as the Nurui CLI.

## What Changed

- Added a standalone `@nurui/mcp` package setup with TypeScript build support.
- Added MCP server entrypoint using stdio transport.
- Added registry service for list/search/detail behavior.
- Added component installer service for writing files, creating `lib/utils`, optional JS conversion, and dependency installation.
- Added tests for registry behavior and installer behavior.
- Added MCP package documentation for users, contributors, and maintainers.
- Added root README pointer to the MCP package.

## Notes

- List and search responses stay compact by default.
- Source code is fetched only when explicitly requested or when the install tool needs it internally.
- Registry URLs are hardcoded as module-level constants, matching the existing CLI style.
- The package must be published before users can run it via `npx @nurui/mcp`.
- Until publishing, local MCP configs should point to `src/mcp/dist/index.js` using an absolute path.

## Validation

- Built the MCP package with `npm test`.
- Verified all MCP package tests pass.
- Smoke-tested MCP tool discovery and confirmed all tools are exposed.
- Tested real-world MCP tool calls using **Codex** and **Antigravity** agents