### PR TITLE
Sanitize dynamic slug parameters and handle missing files in documentation layout

### DIFF
--- a/src/app/(docs)/docs/[slug]/page.tsx
+++ b/src/app/(docs)/docs/[slug]/page.tsx
@@ -36,7 +36,15 @@ export async function generateMetadata({
     `${slug}.mdx`,
   );
 
-  const content = await fs.readFile(filePath, "utf-8");
+  let content: string;
+  try {
+    content = await fs.readFile(filePath, "utf-8");
+  } catch (error: any) {
+    if (error.code === "ENOENT") {
+      notFound();
+    }
+    throw error;
+  }
 
   const { frontmatter } = await compileMDX<Frontmatter>({
     source: content,
@@ -106,7 +114,15 @@ const Page = async ({ params }: AsyncParams) => {
     "docs",
     `${slug}.mdx`,
   );
-  const rawMDX = await fs.readFile(filePath, "utf-8");
+  let rawMDX: string;
+  try {
+    rawMDX = await fs.readFile(filePath, "utf-8");
+  } catch (error: any) {
+    if (error.code === "ENOENT") {
+      notFound();
+    }
+    throw error;
+  }
   const { content } = await compileMDX<Frontmatter>({
     source: rawMDX,
     options: {

--- a/src/app/(docs)/docs/[slug]/page.tsx
+++ b/src/app/(docs)/docs/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { getMDXComponents } from "../../../../../mdx-components";
 import { Metadata } from "next";
 import remarkGfm from "remark-gfm";
 import CopyPage from "@/components/ui/CopyButton";
+import { notFound } from "next/navigation";
 
 interface AsyncParams {
   params: Promise<{ slug: string }>;
@@ -21,6 +22,12 @@ export async function generateMetadata({
   params,
 }: AsyncParams): Promise<Metadata> {
   const { slug } = await params;
+
+  // Whitelist validation: only allow alphanumeric, hyphens, and underscores to prevent path traversal
+  if (!/^[a-zA-Z0-9_-]+$/.test(slug)) {
+    notFound();
+  }
+
   const filePath = path.join(
     process.cwd(),
     "src",
@@ -86,6 +93,12 @@ export async function generateStaticParams() {
 
 const Page = async ({ params }: AsyncParams) => {
   const { slug } = await params;
+
+  // Whitelist validation: only allow alphanumeric, hyphens, and underscores to prevent path traversal
+  if (!/^[a-zA-Z0-9_-]+$/.test(slug)) {
+    notFound();
+  }
+
   const filePath = path.join(
     process.cwd(),
     "src",

--- a/src/app/(docs)/docs/[slug]/page.tsx
+++ b/src/app/(docs)/docs/[slug]/page.tsx
@@ -39,8 +39,13 @@ export async function generateMetadata({
   let content: string;
   try {
     content = await fs.readFile(filePath, "utf-8");
-  } catch (error: any) {
-    if (error.code === "ENOENT") {
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
       notFound();
     }
     throw error;
@@ -117,8 +122,13 @@ const Page = async ({ params }: AsyncParams) => {
   let rawMDX: string;
   try {
     rawMDX = await fs.readFile(filePath, "utf-8");
-  } catch (error: any) {
-    if (error.code === "ENOENT") {
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
       notFound();
     }
     throw error;


### PR DESCRIPTION
This PR adds security validation checks to the dynamic document page slug parameter to prevent directory traversal and adds error handling to cleanly return a `404 Not Found` page when a requested document file does not exist on disk.

## What is Path Traversal?
A path traversal vulnerability occurs when an application uses user-supplied input to construct file paths on the server's disk without validating the input. If the input contains directory navigation sequences like `../` (parent directory steps), the server can be tricked into climbing out of the designated folder and opening sensitive files elsewhere on the filesystem.

## The Problem in the Code
1. **Security Risk:** When loading document files in `src/app/(docs)/docs/[slug]/page.tsx`, the route handler takes the page slug directly from the URL to resolve the file on disk. Without proper checks, a request containing relative directory steps could resolve to files outside the documentation folder.
2. **Server Crashes on Missing Files:** When a dynamic document request is made for a slug that is valid (passes basic character checks) but does not have a corresponding `.mdx` file on disk (e.g., `/docs/animated-list`), `fs.readFile` throws an unhandled `ENOENT` error. This crashes the server with a `500 Internal Server Error` instead of displaying a clean `404 Not Found` page.

## The Solution
* **Input Validation:** Added a validation check to make sure the document name only contains letters, numbers, hyphens, and underscores, preventing directory traversal attempts.
* **Error Handling:** Wrapped the filesystem `readFile` operations in both `generateMetadata()` and the main `Page` component inside `try-catch` blocks. If the file is not found (throwing an `ENOENT` error), the application invokes Next.js's native `notFound()` helper to render a clean `404` page.

## How This Was Tested
* Checked that normal documentation pages (like `neobrutalism-faq`) load and display correctly.
* Checked that requests containing dots or directory segments fail and return a clean `404` page.
* Checked that requests for valid but non-existent components (like `animated-list-2`) cleanly trigger a `404 Not Found` page instead of causing an unhandled server-side crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced documentation page route validation to prevent invalid URL patterns and ensure graceful handling of missing documentation files with proper error pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->